### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          persist-credentials: true # required for private repositories
+          persist-credentials: false
 
       - name: Bump version and push tag
         id: bump_version

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/siutsin/k3s-apiserver-loadbalancer
-  newTag: v1.0.0
+  newTag: v1.1.0

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -321,7 +321,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.0.0
+        image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.1.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary by Sourcery

Bump the controller image tag to v1.1.0 for the new release

Chores:
- Update controller image tag from v1.0.0 to v1.1.0 in kustomization.yaml
- Update controller image tag from v1.0.0 to v1.1.0 in the install manifest