### PR TITLE
fix(ci): allow claude action on dependabot prs

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -72,6 +72,7 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: dependabot[bot]
           track_progress: true
           claude_args: |
             --model opus --allowedTools "Bash(make:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh pr diff:*)"


### PR DESCRIPTION
Summary
- allow dependabot[bot] to trigger the Claude Code action
- fix failing claude and claude-status checks on Dependabot PRs
- keep the change narrowly scoped instead of allowing all bots