### PR TITLE
fix(ci): skip claude on dependabot prs

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -45,6 +45,7 @@ jobs:
     needs: check-files
     if: |
       always() &&
+      github.actor != 'dependabot[bot]' &&
       ((github.event_name == 'pull_request' && needs.check-files.outputs.should-review == 'true') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -72,7 +73,6 @@ jobs:
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: dependabot[bot]
           track_progress: true
           claude_args: |
             --model opus --allowedTools "Bash(make:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh pr diff:*)"


### PR DESCRIPTION
Summary
- skip the claude workflow entirely when the actor is dependabot[bot]
- avoid Dependabot secret limitations for Claude review runs
- remove the now-unneeded claude action bot allowlist entry