### PR TITLE
fix: add workload version labels to installer output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,18 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 
 IGNORE_NOT_FOUND ?= false
 
+define render-install-yaml
+image_no_digest="$${IMG%%@*}"; \
+last_segment="$${image_no_digest##*/}"; \
+case "$$last_segment" in \
+  *:*) version="$${last_segment##*:}" ;; \
+  *) version="latest" ;; \
+esac; \
+sed -e 's|image: controller:latest|image: ${IMG}|' \
+    -e "s|app.kubernetes.io/version: __APP_VERSION__|app.kubernetes.io/version: $$version|g" \
+    deploy/install-template.yaml
+endef
+
 .PHONY: clean
 clean:
 	@echo "Cleaning up..."
@@ -131,17 +143,13 @@ clean:
 .PHONY: build-installer
 build-installer: ## Generate a consolidated YAML with the deployment.
 	mkdir -p dist
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	sed -e 's|image: controller:latest|image: ${IMG}|' -e "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" deploy/install-template.yaml > dist/install.yaml
+	@$(render-install-yaml) > dist/install.yaml
 
 ##@ Deployment
 
 .PHONY: deploy
 deploy: ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	sed -e 's|image: controller:latest|image: ${IMG}|' -e "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" deploy/install-template.yaml | $(KUBECTL) apply -f -
+	@$(render-install-yaml) | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,17 @@ clean:
 .PHONY: build-installer
 build-installer: ## Generate a consolidated YAML with the deployment.
 	mkdir -p dist
-	sed 's|image: controller:latest|image: ${IMG}|' deploy/install-template.yaml > dist/install.yaml
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	sed -e 's|image: controller:latest|image: ${IMG}|' -e "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" deploy/install-template.yaml > dist/install.yaml
 
 ##@ Deployment
 
 .PHONY: deploy
 deploy: ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	sed 's|image: controller:latest|image: ${IMG}|' deploy/install-template.yaml | $(KUBECTL) apply -f -
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	sed -e 's|image: controller:latest|image: ${IMG}|' -e "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" deploy/install-template.yaml | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/deploy/install-template.yaml
+++ b/deploy/install-template.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
-    app.kubernetes.io/version: latest
+    app.kubernetes.io/version: __APP_VERSION__
     control-plane: controller-manager
   name: k3s-apiserver-loadbalancer-system
 ---
@@ -148,6 +148,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
+    app.kubernetes.io/version: __APP_VERSION__
     control-plane: controller-manager
   name: k3s-apiserver-loadbalancer-controller-manager-metrics-service
   namespace: k3s-apiserver-loadbalancer-system
@@ -181,7 +182,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         app.kubernetes.io/name: k3s-apiserver-loadbalancer
-        app.kubernetes.io/version: latest
+        app.kubernetes.io/version: __APP_VERSION__
         control-plane: controller-manager
     spec:
       containers:

--- a/deploy/install-template.yaml
+++ b/deploy/install-template.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
+    app.kubernetes.io/version: latest
     control-plane: controller-manager
   name: k3s-apiserver-loadbalancer-system
 ---
@@ -180,6 +181,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         app.kubernetes.io/name: k3s-apiserver-loadbalancer
+        app.kubernetes.io/version: latest
         control-plane: controller-manager
     spec:
       containers:


### PR DESCRIPTION
## Summary
- add `app.kubernetes.io/version` to the namespace, Deployment, and pod-template metadata for the controller workload
- derive the rendered label value from the `IMG` tag, defaulting to `latest` when no tag is present
- use a dedicated `__APP_VERSION__` placeholder and a shared render helper to avoid broad manifest rewrites

## Verification
- `make build-installer IMG=ghcr.io/siutsin/k3s-apiserver-loadbalancer:v9.9.9`
- `make build-installer IMG=ghcr.io/siutsin/k3s-apiserver-loadbalancer`

## Scope
- this is intentionally limited to workload metadata used by Kubernetes/Kiali views, not every RBAC or service object
